### PR TITLE
Replace library_module by module_library in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ predefined extension sets. For example a module library implemented in
 `src/mylib.ml` can be declared by:
 
 ```ocaml
-Pkg.lib ~exts:Exts.library_module "src/mylib"
+Pkg.lib ~exts:Exts.module_library "src/mylib"
 ```
 which is, effectively, a shortcut for:
 
@@ -228,7 +228,7 @@ presence of another:
 ```ocaml
 let otherlib = Env.bool "otherlib" 
 ...
-Pkg.lib ~cond:otherlib ~exts:Exts.library_module "src/mylib"
+Pkg.lib ~cond:otherlib ~exts:Exts.module_library "src/mylib"
 ```
 
 Conditions related to native code and native code dynamic linking 
@@ -260,7 +260,7 @@ library that needs to be installed in a `subdir` subdirectory of
 `lib` use:
 
 ```
-Pkg.lib ~exts:Exts.library_module ~dst:"subdir/mylib" "src/mylib"
+Pkg.lib ~exts:Exts.module_library ~dst:"subdir/mylib" "src/mylib"
 ```
 
 ## Handling cmt and cmti files


### PR DESCRIPTION
`Exts.library_module` is used in 3 places in the readme. I believe that it is a typo and the correct name is `Exts.module_library` as defined [here](https://github.com/dbuenzli/topkg/blob/master/pkg/topkg.ml#L45).