### PR TITLE
Windows: open the file in binary mode for reading

### DIFF
--- a/pkg/topkg-ext.ml
+++ b/pkg/topkg-ext.ml
@@ -37,7 +37,7 @@ module File : sig
 end = struct
   let exists = Sys.file_exists
   let read file = try
-    let ic = open_in file in
+    let ic = open_in_bin file in
     let len = in_channel_length ic in
     let s = String.create len in
     really_input ic s 0 len; close_in ic; `Ok s


### PR DESCRIPTION
If you open a file in text mode, in_channel_length is not reliable under windows (see the warning at http://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html)
`File.read` could throw an `End_of_file` exception or the returned string can contain garbage.