### PR TITLE
Try to use a better remote path for uploading documentation

### DIFF
--- a/src-bin/toy_github_delegate.ml
+++ b/src-bin/toy_github_delegate.ml
@@ -28,7 +28,7 @@ let repo_docdir_path_from_doc_uri uri =
 let publish_doc_gh_pages uri name version docdir =
   Fpath.of_string docdir
   >>= fun docdir -> repo_docdir_path_from_doc_uri uri
-  >>= fun dir -> (Topkg_care.Delegate.publish_in_git_branch
+  >>= fun dir -> (Topkg_care.Delegate.publish_in_git_branch ~remote:"origin"
                     ~branch:"gh-pages" ~name ~version ~docdir ~dir)
   >>= fun () -> Ok 0
 

--- a/src-bin/toy_github_delegate.ml
+++ b/src-bin/toy_github_delegate.ml
@@ -8,28 +8,64 @@ open Bos_setup
 
 (* Publish documentation *)
 
-let repo_docdir_path_from_doc_uri uri =
+let repo_docdir_owner_repo_and_path_from_doc_uri uri =
   (* Parses the $PATH of $SCHEME://$HOST/$REPO/$PATH *)
   let uri_error uri =
     R.msgf "Could not derive publication directory $PATH from OPAM doc \
             field value %a; expected the pattern \
-            $SCHEME://$HOST/$REPO/$PATH" String.dump uri
+            $SCHEME://$OWNER.github.io/$REPO/$PATH" String.dump uri
   in
   match Topkg_care.Text.split_uri ~rel:true uri with
   | None -> Error (uri_error uri)
-  | Some (_, _, path) ->
+  | Some (_, host, path) ->
       if path = "" then Error (uri_error uri) else
+      (match String.cut ~sep:"." host with
+      | Some (owner, g) when String.equal g "github.io" -> Ok owner
+      | _ -> Error (uri_error uri))
+      >>= fun owner ->
       match String.cut ~sep:"/" path with
-      | None | Some (_, "") -> Ok (Fpath.v ".")
-      | Some (project, path) ->
-          (Fpath.of_string path >>| Fpath.rem_empty_seg)
+      | None -> Error (uri_error uri)
+      | Some (repo, "") -> Ok (owner, repo, Fpath.v ".")
+      | Some (repo, path) ->
+          (Fpath.of_string path >>| fun p -> owner, repo, Fpath.rem_empty_seg p)
           |> R.reword_error_msg (fun _ -> uri_error uri)
 
 let publish_doc_gh_pages uri name version docdir =
   Fpath.of_string docdir
-  >>= fun docdir -> repo_docdir_path_from_doc_uri uri
-  >>= fun dir -> (Topkg_care.Delegate.publish_in_git_branch ~remote:"origin"
-                    ~branch:"gh-pages" ~name ~version ~docdir ~dir)
+  >>= fun docdir -> repo_docdir_owner_repo_and_path_from_doc_uri uri
+  >>= fun (owner, repo, dir) ->
+  let remote = strf "git@github.com:%s/%s.git" owner repo in
+  let git_for_repo r = Cmd.of_list (Topkg.Cmd.to_list @@ Topkg.Vcs.cmd r) in
+  let create_empty_gh_pages git =
+    let msg = "Initial commit by topkg." in
+    let create () =
+      OS.Cmd.run Cmd.(v "git" % "init")
+      >>= fun () -> Topkg.Vcs.get ()
+      >>= fun repo -> Ok (git_for_repo repo)
+      >>= fun git -> OS.Cmd.run Cmd.(git % "checkout" % "--orphan" % "gh-pages")
+      >>= fun () -> (OS.Cmd.run_out Cmd.(v "echo" % msg)
+                     |> OS.Cmd.out_file (Fpath.v "README")
+                     |> OS.Cmd.success)
+      >>= fun () -> OS.Cmd.run Cmd.(git % "add" % "README")
+      >>= fun () -> OS.Cmd.run Cmd.(git % "commit" % "README" % "-m" % msg)
+    in
+    OS.Dir.with_tmp "gh-pages-%s.tmp" (fun dir () ->
+        OS.Dir.with_current dir create () |> R.join
+        >>= fun () -> OS.Cmd.run Cmd.(git % "fetch" % Fpath.to_string dir
+                                      % "gh-pages")
+      ) () |> R.join
+  in
+  Topkg.Vcs.get ()
+  >>= fun repo -> Ok (git_for_repo repo)
+  >>= fun git ->
+  (match OS.Cmd.run Cmd.(git % "fetch" % remote % "gh-pages") with
+  | Ok () -> Ok ()
+  | Error _ -> create_empty_gh_pages git)
+  >>= fun () -> (OS.Cmd.run_out Cmd.(git % "rev-parse" % "FETCH_HEAD")
+                 |> OS.Cmd.to_string)
+  >>= fun id -> OS.Cmd.run Cmd.(git % "branch" % "-f" % "gh-pages" % id)
+  >>= fun () -> Topkg_care.Delegate.publish_in_git_branch ~remote
+                  ~branch:"gh-pages" ~name ~version ~docdir ~dir
   >>= fun () -> Ok 0
 
 (* Publish releases *)
@@ -215,10 +251,10 @@ let main_cmd =
          information about topkg delegates, see topkg-delegate(7).";
      `P "This delegate only supports the following delegations:";
      `I ("$(b,topkg publish doc)",
-         "Commits and pushes the documentation to the gh-branch of the
+         "Commits and pushes the documentation to the gh-pages of the
           source repository. The publication directory PATH in the branch is
           determined by matching the OPAM 'doc' field against the
-          pattern SCHEME://HOST/REPO/PATH.");
+          pattern SCHEME://OWNER.github.io/REPO/PATH.");
      `I ("$(b,topkg publish distrib)",
          "This requires curl(1). Creates a GitHub release with the
          version and publication message given to the delegate and

--- a/src-care/topkg_care.mli
+++ b/src-care/topkg_care.mli
@@ -486,20 +486,21 @@ module Delegate : sig
   (** {2 Helpers} *)
 
   val publish_in_git_branch :
-    branch:string -> name:string -> version:string -> docdir:Fpath.t ->
+    remote:string -> branch:string ->
+    name:string -> version:string -> docdir:Fpath.t ->
     dir:Fpath.t -> (unit, R.msg) result
-  (** [publish_in_git_branch ~branch ~name ~version ~docdir ~dir]
+  (** [publish_in_git_branch ~remote ~branch ~name ~version ~docdir ~dir]
       publishes the documentation directory [docdir] of a package
       named [name] at version [version] by replacing the [dir]
       sub-directory of the branch [branch] of the current working
       directory git repository (use ["."] to copy the docdir at the
-      root directory of the branch).
+      root directory of the branch) and pushes the branch to [remote].
 
       {b Note.} The publication procedure first checkouts the
       [gh-pages] in a temporary clone located in the {!Fpath.parent}
       directory of [docdir]. The [branch] branch of this clone is then
       pushed to the current working git repository, whose [branch]
-      branch is then pushed to the remote repository. *)
+      branch is then pushed to the [remote] repository. *)
 
   (** {1 Issues} *)
 

--- a/src-care/topkg_care_delegate.ml
+++ b/src-care/topkg_care_delegate.ml
@@ -50,7 +50,7 @@ let publish_alt p ~kind ~msg ~archive =
   run_delegate p Cmd.(v "publish" % "alt" % distrib_uri % kind %
                       name % version % msg % p archive)
 
-let publish_in_git_branch ~branch ~name ~version ~docdir ~dir =
+let publish_in_git_branch ~remote ~branch ~name ~version ~docdir ~dir =
   let pp_distrib ppf (name, version) =
     Fmt.pf ppf "%a %a"
       Topkg_care_text.Pp.name name Topkg_care_text.Pp.version version
@@ -110,7 +110,7 @@ let publish_in_git_branch ~branch ~name ~version ~docdir ~dir =
   | true ->
       let push_spec = strf "%s:%s" branch branch in
       Ok (git_for_repo repo) >>= fun git ->
-      OS.Cmd.run Cmd.(git % "push" % "origin" % push_spec)
+      OS.Cmd.run Cmd.(git % "push" % remote % push_spec)
       >>= fun () -> OS.Dir.delete ~recurse:true clonedir
       >>= fun () ->
       log_publish_result "Published documentation for" (name, version) dir;

--- a/src-care/topkg_care_delegate.mli
+++ b/src-care/topkg_care_delegate.mli
@@ -25,7 +25,8 @@ val publish_alt :
   (unit, R.msg) Result.result
 
 val publish_in_git_branch :
-  branch:string -> name:string -> version:string -> docdir:Fpath.t ->
+  remote:string -> branch:string ->
+  name:string -> version:string -> docdir:Fpath.t ->
   dir:Fpath.t -> (unit, R.msg) result
 
 (** {1 Delegate} *)


### PR DESCRIPTION
This is a quick patch to make `tokpg publish doc` work a bit better. This doesn't work yet but feedback is welcome :-)

```
topkg: [INFO] Parsing OPAM file opam
topkg: [EXEC:17049] ["which"; "github-topkg-delegate"]
topkg: [EXEC:17050] ["toy-github-topkg-delegate"; "ipc"; "debug"; "publish";
                     "doc"; "https://mirage.github.io/mirage-http/";
                     "mirage-http"; "v2.5.1-18-ga311db0";
                     "### 2.5.3 (13-06-2016)\n\n* Switch to topkg (#25, @samoht)\n* Fix memory leak in the callback when an exception is raised (#24, @hannesm)";
                     "/Users/thomas/git/mirage-http/_build/mirage-http-2.5.1-18-ga311db0/_build/doc/api.docdir"]
toy-github-topkg-delegate: [ERROR] "": invalid path
topkg: [ERROR] Delegate toy-github-topkg-delegate errored with 2
```
