### PR TITLE
support for --coverage to build with coverage using bisect_ppx

### DIFF
--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -819,6 +819,12 @@ module Conf : sig
       absent the value is [false] or the value of the environment variable
       TOPKG_CONF_PROFILE if specified. *)
 
+  val coverage : t -> bool
+  (** [coverage c] is the value of a predefined key [--coverage] that indicates
+      if the build artefacts include run-time coverage support using bisect_ppx.
+      If absent the value is [false] or the value of the environment variable
+      TOPKG_CONF_COVERAGE if specified. *)
+
   val dump : Format.formatter -> t -> unit
   (** [dump ppf c] formats an unspecified representation of [c] on [ppf]. *)
 
@@ -1174,8 +1180,9 @@ let clean os ~build_dir = OS.Cmd.run @@ Pkg.clean_cmd os ~build_dir
   let build_dir = Conf.build_dir c in
   let debug = Cmd.(on (Conf.debug c) (v "-tag" % "debug")) in
   let profile = Cmd.(on (Conf.profile c) (v "-tag" % "profile")) in
+  let coverage = Cmd.(on (Conf.coverage c) (v "-pkg" % "bisect_ppx")) in
   Cmd.(ocamlbuild % "-use-ocamlfind" % "-classic-display" %% debug %%
-                    profile % "-build-dir" % build_dir)]} *)
+                    profile %% coverage % "-build-dir" % build_dir)]} *)
 
   val clean_cmd : Conf.os -> build_dir:fpath -> Cmd.t
   (** [clean_cmd os ~build_dir] is the default clean command. Its value

--- a/src/topkg_build.ml
+++ b/src/topkg_build.ml
@@ -12,8 +12,11 @@ let build_cmd c os =
   let build_dir = Topkg_conf.build_dir c in
   let debug = Topkg_cmd.(on (Topkg_conf.debug c) (v "-tag" % "debug")) in
   let profile = Topkg_cmd.(on (Topkg_conf.profile c) (v "-tag" % "profile")) in
+  let coverage =
+    Topkg_cmd.(on (Topkg_conf.coverage c) (v "-pkg" % "bisect_ppx"))
+  in
   Topkg_cmd.(ocamlbuild % "-use-ocamlfind" % "-classic-display" %% debug
-             %% profile % "-build-dir" % build_dir)
+             %% profile %% coverage % "-build-dir" % build_dir)
 
 let clean_cmd os ~build_dir =
   let ocamlbuild = Topkg_conf.tool "ocamlbuild" os in

--- a/src/topkg_conf.ml
+++ b/src/topkg_conf.ml
@@ -209,6 +209,13 @@ let profile =
   in
   key "profile" bool ~env:"TOPKG_CONF_PROFILE" ~absent:false ~doc
 
+let coverage =
+  let doc = "Coverage build. Include run-time coverage support in build \
+             artefacts. This key should not be specified explicitely \
+             in your package build instructions."
+  in
+  key "coverage" bool ~env:"TOPKG_CONF_COVERAGE" ~absent:false ~doc
+
 (* Key documentation *)
 
 let pp_cli_opt ppf opt_name absent env doc docv =
@@ -338,6 +345,7 @@ let build_tests c = match value c tests with
 
 let debug c = value c debug
 let profile c = value c profile
+let coverage c = value c coverage
 
 (* OCaml configuration, as communicated by ocamlc -config  *)
 

--- a/src/topkg_conf.mli
+++ b/src/topkg_conf.mli
@@ -70,6 +70,7 @@ val build_tests : t -> bool
 
 val debug : t -> bool
 val profile : t -> bool
+val coverage : t -> bool
 
 (** {1 OCaml configuration} *)
 


### PR DESCRIPTION
The instrumentation for `bisect_ppx` is done by adding `-pkg bisect_ppx` to `ocamlbuild` command line.  Since the OCaml code itself does not depend on bisect, I don't like to have it listed in `_tags` or `opam`.  I currently use [custom `build` scripts](https://github.com/hannesm/arp/blob/95b77f885cc8f803f788457b8e4d622291654f7d/build#L19-L25) just for the instrumenting the library with coverage.

I wasn't able to find another way (maybe in my `pkg/pkg.ml`) to add packages, and am happy if there is another solution than extending `topkg`.