### PR TITLE
Small documentation improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Topkg — The transitory OCaml software packager
 Topkg is a packager for distributing OCaml software. It provides an
 API to describe the files a package installs in a given build
 configuration and to specify information about the package's
-distribution creation and publication procedures.
+distribution, creation and publication procedures.
 
 The optional topkg-care package provides the `topkg` command line tool
 which helps with various aspects of a package's life cycle: creating

--- a/src-bin/doc.ml
+++ b/src-bin/doc.ml
@@ -102,7 +102,7 @@ let man =
     `P "The $(b,$(tname)) command builds the package's API documentation. Use
         the option $(b,-r) to open or refresh the documentation in
         a WWW browser (see $(b,--browser) for details).";
-    `P "$(b,WARNING.) The way this command works is at the moment
+    `P "$(b,WARNING.) The way this command works is at the
         moment very ad-hoc and ocamlbuild specific. It will
         change in the future.";
     `P "Current support relies on having a doc/ directory at the root of the

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1848,7 +1848,7 @@ make it do something useful.
 
 {1:build OPAM and package build instructions}
 
-The package needs to build-depend on [topkg] aswell as [ocamlfind]
+The package needs to build-depend on [topkg] as well as [ocamlfind]
 which is used by the package description file [pkg/pkg.ml] to find the
 [topkg] library; it is likely that you are using [ocamlbuild] too. So
 the depends field of your OPAM file should at least have:

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1904,7 +1904,7 @@ these files.
 
 The {!Pkg.describe} function has a daunting number of arguments and
 configuration options. However if you keep things simple and stick to
-the defaults not much of this does not need to be specified.
+the defaults, much of this does not need to be specified.
 
 In fact if we consider the basic default {{!setup}setup} mentioned
 above for a library described to OCamlbuild in a [src/mylib.mllib]

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -2238,7 +2238,7 @@ To achieve this your package description file can simply condition
 the package install description on the package name
 {{!Conf.pkg_name}communicated by the configuration}. In this setup
 you'll likely have one [$PKG.opam] per [$PKG] at the root of your source
-repository, you should declare them to the description too, so that
+repository, you should declare them in the description too, so that
 they get properly linted and used by the [topkg] tool when appropriate
 (see how the OPAM file is looked up according to the package name
 in {!Pkg.describe}). Here is a blueprint:

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1906,9 +1906,9 @@ The {!Pkg.describe} function has a daunting number of arguments and
 configuration options. However if you keep things simple and stick to
 the defaults, much of this does not need to be specified.
 
-In fact if we consider the basic default {{!setup}setup} mentioned
-above for a library described to OCamlbuild in a [src/mylib.mllib]
-file your package description file [pkg/pkg.ml] simply looks like
+For example, if we consider the basic {{!setup}setup} mentioned
+above for a library described with an OCamlbuild [src/mylib.mllib]
+file, your package description file [pkg/pkg.ml] simply looks like
 this:
 {[
 #!/usr/bin/env ocaml

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -715,9 +715,9 @@ module Conf : sig
       the value of the variable is parsed with [conv] and used instead
       of [absent] when needed.
 
-      [doc] is a documentation string for the key. [docv] is a meta
-      is a documentation to stand for the key value, defaults to the
-      [docv] of [conv]. In [doc] occurences of the substring ["$(docv)"]
+      [doc] is a documentation string for the key. [docv] is a documentation
+      meta-variable to stand for the key value, defaulting to the
+      [docv] of [conv]. In [doc], occurences of the substring ["$(docv)"]
       are replaced by the value of [docv]. *)
 
   val discovered_key :


### PR DESCRIPTION
Add missing comma:
"distribution creation and publication" -> "distribution, creation and publication"
