### PR TITLE
Pkg.ocb_tags

### DIFF
--- a/src/topkg.ml
+++ b/src/topkg.ml
@@ -71,6 +71,9 @@ module Pkg = struct
   let build = Topkg_build.v
   let build_cmd = Topkg_build.build_cmd
   let clean_cmd = Topkg_build.clean_cmd
+  let ocb_tag = Topkg_build.ocb_tag
+  let ocb_bool_tag = Topkg_build.ocb_bool_tag
+  let ocb_bool_tags = Topkg_build.ocb_bool_tags
 
   (* Package *)
 

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1188,6 +1188,27 @@ let clean os ~build_dir = OS.Cmd.run @@ Pkg.clean_cmd os ~build_dir
   Cmd.(ocamlbuild % "-use-ocamlfind" % "-classic-display" %
                     "-build-dir" % build_dir % "-clean") ]} *)
 
+  val ocb_tag : Conf.t -> 'a Conf.key -> string -> Cmd.t
+  (** [ocb_tag c key name] is a command fragment setting the [ocamlbuild]
+      parameterized tag [name] to the value of [key].
+
+      E.g. for [key : bool Conf.key] set to [true], [ocb_tag c key "foo"] sets
+      the tag [foo(true)]. *)
+
+  val ocb_bool_tag : Conf.t -> bool Conf.key -> string -> Cmd.t
+  (** [ocb_bool_tag c key name] is a command fragment setting the [ocamlbuild] tag
+      [name] iff [key] is set to true. *)
+
+  val ocb_bool_tags : Conf.t -> (bool Conf.key * string) list -> Cmd.t
+  (** [ocb_bool_tags c assoc] is a concatenation of {!ocb_bool_tag} for all pairs in
+      [assoc].
+
+      Conditionalize [ocamlbuild] invocation, setting the tag [key_is_true] if
+      the key [key] is set to [true]:
+{[let tags = [(key, "key_is_true")]
+  let cmd c os files =
+    OS.Cmd.run Cmd.(build_cmd %% ocb_bool_tags tags %% of_list files]} *)
+
   (** {1:distrib Distribution description} *)
 
   type watermark = string * [ `String of string | `Version | `Version_num

--- a/src/topkg_build.ml
+++ b/src/topkg_build.ml
@@ -62,6 +62,17 @@ let codec =
   Topkg_codec.version 0 @@
   Topkg_codec.(view ~kind:"build" fields (pair prepare_on_pin dir))
 
+let ocb_tag c key tag =
+  let tag = Topkg_string.strf "%s(%a)" tag (Topkg_conf.pp_value c) key in
+  Topkg_cmd.(v "-tag" % tag)
+
+let ocb_bool_tag c key tag =
+  Topkg_cmd.(on (Topkg_conf.value c key) @@ v "-tag" % tag)
+
+let ocb_bool_tags c tags =
+  let f (key, tag) = Topkg_cmd.(%%) (ocb_bool_tag c key tag) in
+  List.fold_right f tags Topkg_cmd.empty
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/src/topkg_build.mli
+++ b/src/topkg_build.mli
@@ -37,6 +37,10 @@ val clean : t -> (Topkg_conf.os -> build_dir:Topkg_fpath.t -> unit result)
 
 val codec : t Topkg_codec.t
 
+val ocb_tag : Topkg_conf.t -> 'a Topkg_conf.key -> string -> Topkg_cmd.t
+val ocb_bool_tag : Topkg_conf.t -> bool Topkg_conf.key -> string -> Topkg_cmd.t
+val ocb_bool_tags : Topkg_conf.t -> (bool Topkg_conf.key * string) list -> Topkg_cmd.t
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/src/topkg_conf.ml
+++ b/src/topkg_conf.ml
@@ -272,6 +272,8 @@ let value c k = match find k c with
       (Topkg_string.strf "configuration key %s undefined, did you create
          a key after the call to Pkg.describe ?" (* dirty bastard *) k.name)
 
+let pp_value c ppf k = k.conv.print ppf (value c k)
+
 let dump ppf c =
   let dump_binding (Key.V k) v is_first =
     if is_first then () else Format.pp_print_cut ppf ();

--- a/src/topkg_conf.mli
+++ b/src/topkg_conf.mli
@@ -55,6 +55,7 @@ val pp_keys_cli_opts : Format.formatter -> unit -> unit
 type t
 val empty : t
 val value : t -> 'a key -> 'a
+val pp_value : t -> Format.formatter -> 'a key -> unit
 val dump : Format.formatter -> t -> unit
 val of_cli_args :
   pkg_name:string -> build_dir:Topkg_fpath.t -> string list -> t result


### PR DESCRIPTION
Adds a helper converting build configuration keys into `ocamlbuild` tags.
