### PR TITLE
Bypass myocamlbuild.ml for docs

### DIFF
--- a/src-bin/doc.ml
+++ b/src-bin/doc.ml
@@ -14,7 +14,7 @@ let unixy_path p =
 let ocamlbuild build_dir =
   let ocamlbuild = Topkg_care.OCamlbuild.cmd in
   Cmd.(ocamlbuild % "-classic-display" % "-use-ocamlfind" % "-no-links" %
-       "-build-dir" % unixy_path build_dir)
+       "-no-plugin" % "-build-dir" % unixy_path build_dir)
 
 let docflags = Cmd.(v "-docflags" % "-colorize-code,-charset,utf-8")
 


### PR DESCRIPTION
Fixes #80 **if** it makes sense to skip people's `myocamlbuild.ml` for docs.
