### PR TITLE
Flesh out installs

### DIFF
--- a/src/topkg.ml
+++ b/src/topkg.ml
@@ -31,6 +31,8 @@ module Pkg = struct
   type field = Topkg_install.field
   type exec_field = ?auto:bool -> field
 
+  let nothing = Topkg_install.nothing
+  let flatten = Topkg_install.flatten
   let bin = Topkg_install.bin
   let doc = Topkg_install.doc
   let etc = Topkg_install.etc

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -975,6 +975,12 @@ module Pkg : sig
   type install
   (** The type for representing a set of install moves. *)
 
+  val nothing : install
+  (** [nothing] is an empty set of install moves. *)
+
+  val flatten : install list -> install
+  (** [flatten installs] is the union of all the install moves in [installs]. *)
+
   type field =
     ?force:bool -> ?built:bool -> ?cond:bool -> ?exts:Exts.t -> ?dst:fpath ->
     fpath -> install

--- a/src/topkg_install.ml
+++ b/src/topkg_install.ml
@@ -21,6 +21,8 @@ type move_scheme =
 
 type t = move_scheme list
 
+let nothing = []
+
 let flatten ls = (* We don't care about order *)
   let rec push acc = function v :: vs -> push (v :: acc) vs | [] -> acc in
   let rec loop acc = function

--- a/src/topkg_install.mli
+++ b/src/topkg_install.mli
@@ -10,6 +10,7 @@
 
 type t
 
+val nothing : t
 val flatten : t list -> t
 val to_build :
   ?header:string ->


### PR DESCRIPTION
`Pkg.install` being an opaque type makes it pretty difficult to make derived install rules outside of the lib. It's impossible to conditionalize from within combinators, or to pull off certain styles of error recovery.

This is the bare minimum to make the outside interface on par with the private interface.

(`nothing` can, of course, be derived from `flatten`, but comes in handy on its own.)