### PR TITLE
Add a --docflags option to topkg, pass flags to ocamldoc

### DIFF
--- a/src-bin/cli.ml
+++ b/src-bin/cli.ml
@@ -124,6 +124,12 @@ let publish_msg =
   let docv = "MSG" in
   Arg.(value & opt (some string) None & info ["m"; "message"] ~doc ~docv)
 
+let ocamldoc_flags =
+  let doc = "Specifies additional flags to ocamldoc."
+  in
+  let docv = "OCAMLDOC_FLAGS" in
+  Arg.(value & opt (some string) None & info ["docflags"] ~doc ~docv)
+
 (* Terms *)
 
 let logs_to_topkg_log_level = function

--- a/src-bin/cli.mli
+++ b/src-bin/cli.mli
@@ -68,6 +68,10 @@ val build_dir : Fpath.t option Term.t
 val publish_msg : string option Term.t
 (** A [--msg] option to define a publication message. *)
 
+val ocamldoc_flags : string option Term.t
+(** A [--docflags] option to add custom comma-separated ocamldoc flags.
+    The initial flags are -colorize-code, -charset, and utf-8. *)
+
 (** {1 Terms} *)
 
 val setup : unit Term.t


### PR DESCRIPTION
This allows to use custom ocamldoc generators. Perhaps it's best to have it statically configured
in pkg.ml? I haven't used topkg enough to really have an idea and don't know your design choices. Let me know If you'd prefer me to do that :-)
cheers :->