### PR TITLE
Make configuration lookup aware of the --toolchain option

### DIFF
--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -625,39 +625,6 @@ end
 (** Build configuration. *)
 module Conf : sig
 
-  (** {1:tool Tool lookup}
-
-      If your package description needs to run tools (e.g. in the
-      pre and post build hooks, see {!Pkg.build}) it should get the
-      tool to invoke with the following function. This allows to
-      control the executable being run which is useful for
-      cross-compilation scenarios. *)
-
-  type os = [ `Build_os | `Host_os ]
-  (** The type for operating systems.
-      {ul
-      {- [`Build_os] is the build OS, the OS on which the package is built.}
-      {- [`Host_os] is the host OS, the OS on which the package is hosted
-         and runs.}} *)
-
-  val tool : string -> os -> Cmd.t
-  (** [tool cmd os] is a command [cmd] which can be run on the build OS
-      which produces output suitable for the OS [os].
-
-      The actual command returned depends on the following lookup procedure,
-      here exemplified on the invocation [tool "mytool" `Host_os] (resp.
-      [`Build_os]).
-      {ol
-      {- [Cmd.v "cmd"], if the environment variable HOST_OS_MYTOOL (resp.
-         BUILD_OS_MYTOOL) is set to ["cmd"]}
-      {- [Cmd.v (Fpath.append path "mytool")], if the environment variable
-         HOST_OS_XBIN  (resp. BUILD_OS_BIN) is set to [path].}
-      {- [Cmd.v ("mytool" ^ "suff")], if the environment variable
-         HOST_OS_SUFF (resp. BUILD_OS_SUFF).}
-      {- [Cmd.(v "ocamlfind" % "mytool")] if ["mytool"] is part of
-         the OCaml tools that can be invoked through ocamlfind.}
-      {- [Cmd.v "mytool"] otherwise.}} *)
-
   (** {1:kconv Key value converters} *)
 
   type 'a conv
@@ -847,6 +814,43 @@ module Conf : sig
 
   val dump : Format.formatter -> t -> unit
   (** [dump ppf c] formats an unspecified representation of [c] on [ppf]. *)
+
+  (** {1:tool Tool lookup}
+
+      If your package description needs to run tools (e.g. in the
+      pre and post build hooks, see {!Pkg.build}) it should get the
+      tool to invoke with the following function. This allows to
+      control the executable being run which is useful for
+      cross-compilation scenarios. *)
+
+  type os = [ `Build_os | `Host_os ]
+  (** The type for operating systems.
+      {ul
+      {- [`Build_os] is the build OS, the OS on which the package is built.}
+      {- [`Host_os] is the host OS, the OS on which the package is hosted
+         and runs.}} *)
+
+  val tool : ?conf:t -> string -> os -> Cmd.t
+  (** [tool ~conf cmd os] is a command [cmd] which can be run on the build OS
+      which produces output suitable for the OS [os], taking into account
+      configuration [conf].
+
+      The actual command returned depends on the following lookup procedure,
+      here exemplified on the invocation [tool "mytool" `Host_os] (resp.
+      [`Build_os]).
+      {ol
+      {- [Cmd.v "cmd"], if the environment variable HOST_OS_MYTOOL (resp.
+         BUILD_OS_MYTOOL) is set to ["cmd"]}
+      {- [Cmd.v (Fpath.append path "mytool")], if the environment variable
+         HOST_OS_XBIN  (resp. BUILD_OS_BIN) is set to [path].}
+      {- [Cmd.v ("mytool" ^ "suff")], if the environment variable
+         HOST_OS_SUFF (resp. BUILD_OS_SUFF).}
+      {- [Cmd.(v "ocamlfind" % "-toolchain" % "toolchain" % "mytool")] if
+         ["mytool"] is part of the OCaml tools that can be invoked through
+         ocamlfind, [toolchain conf] is not [None], and [os] is [`Host_os].}
+      {- [Cmd.(v "ocamlfind" % "mytool")] if ["mytool"] is part of
+         the OCaml tools that can be invoked through ocamlfind.}
+      {- [Cmd.v "mytool"] otherwise.}} *)
 
   (** {1:ocaml OCaml configuration} *)
 

--- a/src/topkg_conf.mli
+++ b/src/topkg_conf.mli
@@ -10,11 +10,6 @@
 
 open Topkg_result
 
-(** {1 Tool lookup} *)
-
-type os = [ `Build_os | `Host_os ]
-val tool : string -> os -> Topkg_cmd.t
-
 (** {1 Configuration key value converters} *)
 
 type 'a conv
@@ -75,6 +70,10 @@ val debugger_support : t -> bool
 val profile : t -> bool
 val toolchain : t -> string option
 
+(** {1 Tool lookup} *)
+
+type os = [ `Build_os | `Host_os ]
+val tool : ?conf:t -> string -> os -> Topkg_cmd.t
 
 (** {1 OCaml configuration} *)
 


### PR DESCRIPTION
Before this commit, the .install file was generated using the ocamlc
configuration for the build system. When cross-compiling, this causes
it to contain incorrect extensions, e.g. dllfoo.so for Windows, though
this did not actually cause installation failures because of the way
opam-installer works.

This commit is larger than it looks, because unfortunately I had
to move code around a bunch. The solution with an optional argument
to Topkg_conf.tool is also somewhat ugly, but making it mandatory
resulted in a cascade of API changes, some of which are probably
breaking (I don't know what is the topkg API stability policy) and
some I do not know how to fix (the invocations in Topkg_care_ipc,
for example).

Ultimately it's just passing `-toolchain` to the `ocamlfind ocamlc`
invocation.

Also, once this PR is merged, topkg will become the first packager
tool that has first-class support for cross-compilation. I will start
looking at changes to opam that will allow to completely reuse
opam files...