### PR TITLE
Set correct exit code

### DIFF
--- a/src-bin/topkg_bin.ml
+++ b/src-bin/topkg_bin.ml
@@ -39,7 +39,7 @@ let main =
 
 let main () =
   Topkg.Private.disable_main ();
-  Term.(exit @@ eval_choice main cmds)
+  Term.(exit_status @@ eval_choice main cmds)
 
 let () = main ()
 


### PR DESCRIPTION
The version in `master` uses `Term.exit`, which returns 0 for all "Ok" cases.

This causes commands like `topkg build` to exit with 0 even when `ocaml pkg/pkg.ml build` fails (they correctly return using `Ok 1` which is then ignored).

Thanks!