### PR TITLE
Extend watermarking with edition commands

### DIFF
--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1455,7 +1455,7 @@ fun () -> Ok [".git"; ".gitignore"; ".gitattributes"; ".hg"; ".hgignore";
 
   val opam_file :
     ?lint:bool -> ?lint_deps_excluding:string list option -> ?install:bool ->
-    fpath -> opam_file
+    ?insert_version:bool -> fpath -> opam_file
   (** [opam_file ~lint ~lint_deps_excluding ~install p] is an opam file
       [p] expressd relative to the distribution root directory such that:
       {ul
@@ -1471,7 +1471,9 @@ fun () -> Ok [".git"; ".gitignore"; ".gitattributes"; ".hg"; ".hgignore";
          {- Package names that start with ["conf-"]}
          {- {!Topkg_care.OCamlfind.base_packages}}
          {- {!Topkg_care.Opam.ocaml_base_packages}}}
-         If [None] the dependency check is disabled.}} *)
+         If [None] the dependency check is disabled.}
+      {- If [insert_version] is [true] (default), the version is automacally
+         inserted in step 2. of {{!distdetails}distribution creation}} *)
 
   val describe :
     ?delegate:Cmd.t ->

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -392,6 +392,26 @@ module OS : sig
         of a string of the form ["%%ID%%"] in [content] is replaced by the
         value of [List.assoc "ID" vars], if any. *)
 
+    (** Edition commands for {!write_edit}:
+        {ul
+        {- [`Replace_by s], replaces [%%ID%%] by [s].}
+        {- [`Delete_bol], delete everything from the beginning of the
+           current line to the end of [%%ID%%].}
+        {- [`Delete_eol], deletes everything from the beginning [%%ID%%] to the
+           end of the current line.}
+        {- [`Delete_line], deletes the current line entirely.}}
+    *)
+    type edition_command =
+      [ `Replace_by of string
+      | `Delete_bol
+      | `Delete_eol
+      | `Delete_line ]
+
+    val write_edit : fpath -> (string * edition_command) list -> string -> unit result
+    (** [write_edit file vars content] is like {!write} except any occurence
+        of a string of the form ["%%ID%%"] in [content] is interpreted by the
+        value of [List.assoc "ID" vars], if any. *)
+
     (** {1:tmpfiles Temporary files} *)
 
     val tmp : unit -> fpath result

--- a/src/topkg.mli
+++ b/src/topkg.mli
@@ -1298,7 +1298,8 @@ let clean os ~build_dir = OS.Cmd.run @@ Pkg.clean_cmd os ~build_dir
 
   type watermark = string * [ `String of string | `Version | `Version_num
                             | `Name | `Vcs of [`Commit_id]
-                            | `Opam of fpath option * string * string]
+                            | `Opam of fpath option * string * string
+                            | `Delete_bol | `Delete_eol | `Delete_line]
   (** The type for watermarks. A watermark identifier, e.g. ["ID"] and its
       definition:
       {ul
@@ -1318,7 +1319,13 @@ let clean os ~build_dir = OS.Cmd.run @@ Pkg.clean_cmd os ~build_dir
          {!Topkg_care.Opam.File.field_names}.  {b Warning.} In
          {{!Conf.build_context}dev package ([`Pin]) builds}, [`Opam]
          watermarks are only substituted if the package [topkg-care] is
-         installed.}}
+         installed.}
+      {- [`Delete_bol], is a special identifieer that deletes everything from
+         the beginning of the current line to the end of the watermark.}
+      {- [`Delete_eol], is a special identifieer that deletes everything from
+         the beginning of the watermark to the end of the current line.}
+      {- [`Delete_line], is a special identifieer that deletes the current
+         line entirely.}}
 
       When a file is watermarked with an identifier ["ID"], any occurence of
       the sequence [%%ID%%] in its content is substituted by its definition. *)
@@ -1379,12 +1386,15 @@ let clean os ~build_dir = OS.Cmd.run @@ Pkg.clean_cmd os ~build_dir
       {- [("VERSION_NUM", `Version_num)]}
       {- [("VCS_COMMIT_ID", `Vcs [`Commit_id])]}
       {- [("PKG_MAINTAINER", `Opam (None, "maintainer", ", "))]}
-      {- [("PKG_AUTHORS", `Opam (None, "authors", ", ")]}
-      {- [("PKG_HOMEPAGE", `Opam (None, "homepage", " ")]}
-      {- [("PKG_ISSUES", `Opam (None, "bug-reports", " ")]}
+      {- [("PKG_AUTHORS", `Opam (None, "authors", ", "))]}
+      {- [("PKG_HOMEPAGE", `Opam (None, "homepage", " "))]}
+      {- [("PKG_ISSUES", `Opam (None, "bug-reports", " "))]}
       {- [("PKG_DOC", `Opam (None, "doc", " "))]}
-      {- [("PKG_LICENSE", `Opam (None, "license", ", ")]}
-      {- [("PKG_REPO", `Opam (None, "dev-repo", " "))]}}
+      {- [("PKG_LICENSE", `Opam (None, "license", ", "))]}
+      {- [("PKG_REPO", `Opam (None, "dev-repo", " "))]}
+      {- [("<<", `Delete_bol)]}
+      {- [(">>", `Delete_eol)]}
+      {- [("DELETE_LINE", `Delete_line)]}}
       Prepending to the list overrides default definitions. *)
 
   val files_to_watermark : unit -> fpath list result

--- a/src/topkg_distrib.mli
+++ b/src/topkg_distrib.mli
@@ -17,15 +17,20 @@ open Topkg_result
 type watermark =
   string *
   [ `String of string | `Name | `Version | `Version_num | `Vcs of [ `Commit_id ]
-  | `Opam of Topkg_fpath.t option * string * string ]
+  | `Opam of Topkg_fpath.t option * string * string
+  | `Delete_bol | `Delete_eol | `Delete_line ]
+
 
 val define_watermarks :
   name:string -> version:string -> opam:Topkg_fpath.t ->
-  watermark list -> (string * string) list
+  watermark list -> (string * Topkg_os.File.edition_command) list
 
-val watermark_file : (string * string) list -> Topkg_fpath.t -> unit result
+val watermark_file :
+  (string * Topkg_os.File.edition_command) list -> Topkg_fpath.t -> unit result
 val watermark_files :
-  (string * string) list -> Topkg_fpath.t list -> unit result
+  (string * Topkg_os.File.edition_command) list ->
+  Topkg_fpath.t list ->
+  unit result
 
 (* Distribution *)
 

--- a/src/topkg_os.mli
+++ b/src/topkg_os.mli
@@ -34,6 +34,14 @@ module File : sig
     val write_subst :
       Topkg_fpath.t -> (string * string) list -> string -> unit result
 
+    type edition_command =
+      [ `Replace_by of string
+      | `Delete_bol
+      | `Delete_eol
+      | `Delete_line ]
+    val write_edit :
+      Topkg_fpath.t -> (string * edition_command) list -> string -> unit result
+
     val tmp : unit -> Topkg_fpath.t result
 end
 

--- a/src/topkg_pkg.mli
+++ b/src/topkg_pkg.mli
@@ -19,7 +19,7 @@ val meta_file : ?lint:bool -> ?install:bool -> Topkg_fpath.t -> meta_file
 type opam_file
 val opam_file :
   ?lint:bool -> ?lint_deps_excluding:string list option -> ?install:bool ->
-  Topkg_fpath.t -> opam_file
+  ?insert_version:bool -> Topkg_fpath.t -> opam_file
 
 type t
 


### PR DESCRIPTION
This PR extends watermarking to add a few edition commands. The main motivation is to allow to put the `%%VERSION%%` string in a comment in the `README.md` file, so that it is not displayed on github. I don't like seeing it on the project page.

## Implementation

### Topkg.OS.File.write_edit

The first commit adds a function `Topkg.OS.File.write_edit` which extends `write_subst`:

```ocaml
(** Edition commands for {!write_edit}:
    {ul
    {- [`Replace_by s], replaces [%%ID%%] by [s].}
    {- [`Delete_bol], delete everything from the beginning of the
       current line to the end of [%%ID%%].}
    {- [`Delete_eol], deletes everything from the beginning [%%ID%%] to the
       end of the current line.}
    {- [`Delete_line], deletes the current line entirely.}}
*)
 type edition_command =
  [ `Replace_by of string
  | `Delete_bol
  | `Delete_eol
  | `Delete_line ]

val write_edit : fpath -> (string * edition_command) list -> string -> unit result
(** [write_edit file vars content] is like {!write} except any occurence
    of a string of the form ["%%ID%%"] in [content] is interpreted by the
    value of [List.assoc "ID" vars], if any. *)
```

I rewrote `write_subst` into two steps: a step that computes the substitutions and a step that applies them, to make it easier to detect overlapping substitutions.

### Default bindings

The second commit adds the edition command to the type `Topkg.Pkg.watermarks` and to the default watermarks:

```ocaml
  val watermarks : watermark list
  (** [...]
     {- [("<<", `Delete_bol)]}
     {- [(">>", `Delete_eol)]}
     {- [("DELETE_LINE", `Delete_line)]}
     [...] *)
```

With this two commits, one can write this in its `README.md` file:

```html
<!-- %%<<%%%%VERSION%%%%>>%% -->
```

Changing the default watermarks is a breaking change, so I can remove the default bindings if you prefer.

### Explicit control of the version in opam files

The last commit adds an optional `?insert_version:bool` argument to `Topkg.Pkg.opam_file`, allowing one to disable the automatic insertion of the version in opam files. This gives more control to the user. For instance, one can write:

```
...
#%%<<%%version: "%%VERSION%%"
version: "dev" #%%DELETE_LINE%%
...
```

This also makes the preparation step a fix point. Currently calling `ocaml pkg/pkg.ml build --pinned true` n times adds n `version: ...` lines to the opam files.