### PR TITLE
use `command -v` instead of `type in Topkg_os.Cmd.exists

### DIFF
--- a/src/topkg_os.ml
+++ b/src/topkg_os.ml
@@ -225,7 +225,7 @@ module Cmd = struct
 
   let test_cmd = match Sys.os_type with
   | "Win32" -> Topkg_cmd.v "where"
-  | _ -> Topkg_cmd.v "type"
+  | _ -> Topkg_cmd.(v "command" % "-v")
 
   let cmd_bin cmd =
     try List.hd (Topkg_cmd.to_list cmd) with


### PR DESCRIPTION
on OpenBSD, `type` is not a builtin, but an alias to `whence -v` - thus
`ocaml pkg/pkg.ml build --pinned true` - which discovers `git` or `hg` - fails

similar code has been fixed in bos (see https://github.com/dbuenzli/bos/issues/52) and earlier discussion in #39.

With this change, workarounds (such as https://github.com/mirage/mirage-solo5/pull/30/files#diff-1f947de1e211dae385d88d792a4fd397 and similar https://github.com/hannesm/jackline/blob/afee826c5d297f5c2dfe95dc41b8a80c54be9ef9/opam#L10-L13 are no longer needed).