### PR TITLE
Also check `Stublibs when dropping shared libraries

### DIFF
--- a/src/topkg_install.ml
+++ b/src/topkg_install.ml
@@ -71,7 +71,7 @@ let to_build ?header c os i =
       let src = file_to_str src in
       let drop = not m.force && match m.field with
       | `Bin -> List.exists (Filename.check_suffix src) bin_drops
-      | `Lib -> List.exists (Filename.check_suffix src) lib_drops
+      | `Lib | `Stublibs -> List.exists (Filename.check_suffix src) lib_drops
       | _ -> false
       in
       if drop then (targets, moves, tests) else


### PR DESCRIPTION
Continuation of https://github.com/dbuenzli/topkg/issues/136