### PR TITLE
Compatibility fix for 4.12

### DIFF
--- a/src/topkg_opam.ml
+++ b/src/topkg_opam.ml
@@ -107,7 +107,7 @@ module Install = struct
       field
     in
     let sortable (field, mv) = (field_to_string field, mv) in
-    let moves = List.(sort compare (rev_map sortable mvs)) in
+    let moves = List.sort compare (List.rev_map sortable mvs) in
     pr_header b h;
     let last = List.fold_left (pr_move b) "" moves in
     pr_field_end b last;


### PR DESCRIPTION
The `List.compare` function recently introduced in the 4.12 branch is shadowing a compare function.
This PR removes the local open that was causing this shadowing.